### PR TITLE
Add email-based account recovery (forgot password / forgot username)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
+      # id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -28,13 +28,17 @@ jobs:
           script: |
             TAG=${{ github.ref_name }}
             echo $TAG
+            
+            DOCKER_TAG=$(echo "$TAG" | tr '/' '-')
+            echo $DOCKER_TAG
+            
             cd ${{ env.SERVER_APP_DIR }}
             docker stop ${{ env.CONTAINER_NAME }} || true
             docker rm ${{ env.CONTAINER_NAME }} || true
 
             rm -rf src_temp || true
             git clone -b $TAG --depth 1 https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git src_temp
-            docker build -t ${{ env.DOCKER_REPO }}:$TAG src_temp
+            docker build -t ${{ env.DOCKER_REPO }}:$DOCKER_TAG src_temp
             rm -rf src_temp
 
             docker run -d \

--- a/SplitServer.Tests/ValidationServiceTests.cs
+++ b/SplitServer.Tests/ValidationServiceTests.cs
@@ -62,4 +62,56 @@ public class ValidationServiceTests
 
         Assert.True(result.IsSuccess);
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("plainaddress")]
+    [InlineData("@no-local.com")]
+    [InlineData("no-at-sign.com")]
+    [InlineData("no-tld@example")]
+    [InlineData("spaces in@email.com")]
+    [InlineData("trailing-space@email.com ")]
+    [InlineData("a@b@c.com")]
+    public void ValidateEmail_ShouldReturnFailure_WhenEmailIsInvalid(string email)
+    {
+        var validationService = new ValidationService();
+
+        var result = validationService.ValidateEmail(email);
+
+        Assert.True(result.IsFailure);
+
+        _testOutputHelper.WriteLine(result.Error);
+    }
+
+    [Fact]
+    public void ValidateEmail_ShouldReturnFailure_WhenEmailExceedsMaxLength()
+    {
+        var validationService = new ValidationService();
+
+        var localPart = new string('a', 250);
+        var email = $"{localPart}@example.com";
+
+        var result = validationService.ValidateEmail(email);
+
+        Assert.True(result.IsFailure);
+
+        _testOutputHelper.WriteLine(result.Error);
+    }
+
+    [Theory]
+    [InlineData("user@example.com")]
+    [InlineData("user.name@example.com")]
+    [InlineData("user+tag@example.co.uk")]
+    [InlineData("USER@EXAMPLE.COM")]
+    [InlineData("123@example.io")]
+    [InlineData("a@b.cd")]
+    public void ValidateEmail_ShouldReturnSuccess_WhenEmailIsValid(string email)
+    {
+        var validationService = new ValidationService();
+
+        var result = validationService.ValidateEmail(email);
+
+        Assert.True(result.IsSuccess);
+    }
 }

--- a/SplitServer/Commands/ProcessGoogleCodeCommandHandler.cs
+++ b/SplitServer/Commands/ProcessGoogleCodeCommandHandler.cs
@@ -105,6 +105,7 @@ public class ProcessGoogleCodeCommandHandler : IRequestHandler<ProcessGoogleCode
             Created = now,
             Updated = now,
             Email = googleUserInfo.Email,
+            EmailVerified = true,
             HashedPassword = null,
             Username = generatedUsername,
             GoogleId = googleUserInfo.Id,

--- a/SplitServer/Commands/RequestPasswordResetCommand.cs
+++ b/SplitServer/Commands/RequestPasswordResetCommand.cs
@@ -1,0 +1,9 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace SplitServer.Commands;
+
+public class RequestPasswordResetCommand : IRequest<Result>
+{
+    public required string Email { get; init; }
+}

--- a/SplitServer/Commands/RequestPasswordResetCommandHandler.cs
+++ b/SplitServer/Commands/RequestPasswordResetCommandHandler.cs
@@ -1,0 +1,103 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+using Microsoft.Extensions.Options;
+using Serilog;
+using SplitServer.Configuration;
+using SplitServer.Models;
+using SplitServer.Repositories;
+using SplitServer.Services.Email;
+
+namespace SplitServer.Commands;
+
+public class RequestPasswordResetCommandHandler : IRequestHandler<RequestPasswordResetCommand, Result>
+{
+    private const int PasswordResetTokenTtlMinutes = 60;
+
+    private readonly IUsersRepository _usersRepository;
+    private readonly IEmailVerificationCodesRepository _codesRepository;
+    private readonly IEmailSender _emailSender;
+    private readonly EmailTokenService _tokenService;
+    private readonly AuthSettings _authSettings;
+
+    public RequestPasswordResetCommandHandler(
+        IUsersRepository usersRepository,
+        IEmailVerificationCodesRepository codesRepository,
+        IEmailSender emailSender,
+        EmailTokenService tokenService,
+        IOptions<AuthSettings> authSettings)
+    {
+        _usersRepository = usersRepository;
+        _codesRepository = codesRepository;
+        _emailSender = emailSender;
+        _tokenService = tokenService;
+        _authSettings = authSettings.Value;
+    }
+
+    public async Task<Result> Handle(RequestPasswordResetCommand command, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(command.Email))
+        {
+            return Result.Success();
+        }
+
+        var userMaybe = await _usersRepository.GetByEmail(command.Email, ct);
+
+        if (userMaybe.HasNoValue || !userMaybe.Value.EmailVerified)
+        {
+            return Result.Success();
+        }
+
+        var user = userMaybe.Value;
+        var now = DateTime.UtcNow;
+
+        var invalidateResult = await _codesRepository.InvalidateActiveCodes(
+            user.Id,
+            EmailVerificationCodePurpose.PasswordReset,
+            ct);
+
+        if (invalidateResult.IsFailure)
+        {
+            Log.Warning("Failed to invalidate existing reset codes for user {UserId}", user.Id);
+        }
+
+        var plaintextToken = _tokenService.GeneratePasswordResetToken();
+        var tokenHash = _tokenService.Hash(plaintextToken);
+
+        var code = new EmailVerificationCode
+        {
+            Id = Guid.NewGuid().ToString(),
+            Created = now,
+            Updated = now,
+            UserId = user.Id,
+            CodeHash = tokenHash,
+            Purpose = EmailVerificationCodePurpose.PasswordReset,
+            ExpiresAt = now.AddMinutes(PasswordResetTokenTtlMinutes),
+            ConsumedAt = null,
+        };
+
+        var insertResult = await _codesRepository.Insert(code, ct);
+
+        if (insertResult.IsFailure)
+        {
+            return Result.Success();
+        }
+
+        var resetLink = $"{_authSettings.ClientUrl.TrimEnd('/')}/reset-password?token={plaintextToken}";
+
+        var body =
+            $"Hi {user.Username},\n\n" +
+            "We received a request to reset your password.\n" +
+            $"Click the link below to choose a new password. This link expires in {PasswordResetTokenTtlMinutes} minutes.\n\n" +
+            $"{resetLink}\n\n" +
+            "If you did not request this, you can ignore this email.";
+
+        var sendResult = await _emailSender.SendAsync(user.Email!, "Reset your password", body, ct);
+
+        if (sendResult.IsFailure)
+        {
+            Log.Warning("Failed to send password reset email for user {UserId}: {Error}", user.Id, sendResult.Error);
+        }
+
+        return Result.Success();
+    }
+}

--- a/SplitServer/Commands/RequestUsernameRecoveryCommand.cs
+++ b/SplitServer/Commands/RequestUsernameRecoveryCommand.cs
@@ -1,0 +1,9 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace SplitServer.Commands;
+
+public class RequestUsernameRecoveryCommand : IRequest<Result>
+{
+    public required string Email { get; init; }
+}

--- a/SplitServer/Commands/RequestUsernameRecoveryCommandHandler.cs
+++ b/SplitServer/Commands/RequestUsernameRecoveryCommandHandler.cs
@@ -1,0 +1,52 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+using Serilog;
+using SplitServer.Repositories;
+using SplitServer.Services.Email;
+
+namespace SplitServer.Commands;
+
+public class RequestUsernameRecoveryCommandHandler : IRequestHandler<RequestUsernameRecoveryCommand, Result>
+{
+    private readonly IUsersRepository _usersRepository;
+    private readonly IEmailSender _emailSender;
+
+    public RequestUsernameRecoveryCommandHandler(
+        IUsersRepository usersRepository,
+        IEmailSender emailSender)
+    {
+        _usersRepository = usersRepository;
+        _emailSender = emailSender;
+    }
+
+    public async Task<Result> Handle(RequestUsernameRecoveryCommand command, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(command.Email))
+        {
+            return Result.Success();
+        }
+
+        var userMaybe = await _usersRepository.GetByEmail(command.Email, ct);
+
+        if (userMaybe.HasNoValue || !userMaybe.Value.EmailVerified)
+        {
+            return Result.Success();
+        }
+
+        var user = userMaybe.Value;
+
+        var body =
+            $"Hi,\n\n" +
+            $"Your username is: {user.Username}\n\n" +
+            "If you did not request this, you can ignore this email.";
+
+        var sendResult = await _emailSender.SendAsync(user.Email!, "Your username", body, ct);
+
+        if (sendResult.IsFailure)
+        {
+            Log.Warning("Failed to send username recovery email for user {UserId}: {Error}", user.Id, sendResult.Error);
+        }
+
+        return Result.Success();
+    }
+}

--- a/SplitServer/Commands/ResetPasswordCommand.cs
+++ b/SplitServer/Commands/ResetPasswordCommand.cs
@@ -1,0 +1,10 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace SplitServer.Commands;
+
+public class ResetPasswordCommand : IRequest<Result>
+{
+    public required string Token { get; init; }
+    public required string NewPassword { get; init; }
+}

--- a/SplitServer/Commands/ResetPasswordCommandHandler.cs
+++ b/SplitServer/Commands/ResetPasswordCommandHandler.cs
@@ -1,0 +1,100 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using SplitServer.Models;
+using SplitServer.Repositories;
+using SplitServer.Services.Email;
+
+namespace SplitServer.Commands;
+
+public class ResetPasswordCommandHandler : IRequestHandler<ResetPasswordCommand, Result>
+{
+    private const string InvalidOrExpiredError = "Invalid or expired token";
+
+    private readonly IUsersRepository _usersRepository;
+    private readonly IEmailVerificationCodesRepository _codesRepository;
+    private readonly ISessionsRepository _sessionsRepository;
+    private readonly EmailTokenService _tokenService;
+
+    public ResetPasswordCommandHandler(
+        IUsersRepository usersRepository,
+        IEmailVerificationCodesRepository codesRepository,
+        ISessionsRepository sessionsRepository,
+        EmailTokenService tokenService)
+    {
+        _usersRepository = usersRepository;
+        _codesRepository = codesRepository;
+        _sessionsRepository = sessionsRepository;
+        _tokenService = tokenService;
+    }
+
+    public async Task<Result> Handle(ResetPasswordCommand command, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(command.Token) || string.IsNullOrWhiteSpace(command.NewPassword))
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var tokenHash = _tokenService.Hash(command.Token);
+
+        var codeMaybe = await _codesRepository.GetActiveByCodeHash(
+            tokenHash,
+            EmailVerificationCodePurpose.PasswordReset,
+            ct);
+
+        if (codeMaybe.HasNoValue)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var code = codeMaybe.Value;
+        var now = DateTime.UtcNow;
+
+        if (code.ExpiresAt <= now || code.ConsumedAt is not null)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var userMaybe = await _usersRepository.GetById(code.UserId, ct);
+
+        if (userMaybe.HasNoValue)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var user = userMaybe.Value;
+
+        var hasher = new PasswordHasher<string>();
+        var newHashedPassword = hasher.HashPassword(user.Id, command.NewPassword);
+
+        var updateUserResult = await _usersRepository.Update(
+            user with
+            {
+                HashedPassword = newHashedPassword,
+                Updated = now
+            },
+            ct);
+
+        if (updateUserResult.IsFailure)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var consumeResult = await _codesRepository.Update(
+            code with
+            {
+                ConsumedAt = now,
+                Updated = now
+            },
+            ct);
+
+        if (consumeResult.IsFailure)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        await _sessionsRepository.DeleteByUserId(user.Id, ct);
+
+        return Result.Success();
+    }
+}

--- a/SplitServer/Commands/SetAccountEmailCommand.cs
+++ b/SplitServer/Commands/SetAccountEmailCommand.cs
@@ -1,0 +1,10 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace SplitServer.Commands;
+
+public class SetAccountEmailCommand : IRequest<Result>
+{
+    public required string UserId { get; init; }
+    public required string Email { get; init; }
+}

--- a/SplitServer/Commands/SetAccountEmailCommandHandler.cs
+++ b/SplitServer/Commands/SetAccountEmailCommandHandler.cs
@@ -1,0 +1,129 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+using Serilog;
+using SplitServer.Models;
+using SplitServer.Repositories;
+using SplitServer.Services;
+using SplitServer.Services.Email;
+
+namespace SplitServer.Commands;
+
+public class SetAccountEmailCommandHandler : IRequestHandler<SetAccountEmailCommand, Result>
+{
+    private const int VerificationCodeTtlMinutes = 10;
+
+    private readonly IUsersRepository _usersRepository;
+    private readonly IEmailVerificationCodesRepository _codesRepository;
+    private readonly IEmailSender _emailSender;
+    private readonly EmailTokenService _tokenService;
+    private readonly ValidationService _validationService;
+
+    public SetAccountEmailCommandHandler(
+        IUsersRepository usersRepository,
+        IEmailVerificationCodesRepository codesRepository,
+        IEmailSender emailSender,
+        EmailTokenService tokenService,
+        ValidationService validationService)
+    {
+        _usersRepository = usersRepository;
+        _codesRepository = codesRepository;
+        _emailSender = emailSender;
+        _tokenService = tokenService;
+        _validationService = validationService;
+    }
+
+    public async Task<Result> Handle(SetAccountEmailCommand command, CancellationToken ct)
+    {
+        var emailValidationResult = _validationService.ValidateEmail(command.Email);
+
+        if (emailValidationResult.IsFailure)
+        {
+            return emailValidationResult;
+        }
+
+        var userMaybe = await _usersRepository.GetById(command.UserId, ct);
+
+        if (userMaybe.HasNoValue)
+        {
+            return Result.Failure($"User with id {command.UserId} was not found");
+        }
+
+        var user = userMaybe.Value;
+
+        var isSameAsCurrent = user.Email is not null &&
+                              string.Equals(user.Email, command.Email, StringComparison.InvariantCultureIgnoreCase);
+
+        if (!isSameAsCurrent)
+        {
+            var emailOwnerMaybe = await _usersRepository.GetByEmail(command.Email, ct);
+
+            if (emailOwnerMaybe.HasValue && emailOwnerMaybe.Value.Id != user.Id)
+            {
+                return Result.Failure("An account with this email already exists");
+            }
+        }
+
+        var now = DateTime.UtcNow;
+
+        var updateResult = await _usersRepository.Update(
+            user with
+            {
+                Email = command.Email,
+                EmailVerified = false,
+                Updated = now,
+            },
+            ct);
+
+        if (updateResult.IsFailure)
+        {
+            return updateResult;
+        }
+
+        var invalidateResult = await _codesRepository.InvalidateActiveCodes(
+            user.Id,
+            EmailVerificationCodePurpose.VerifyEmail,
+            ct);
+
+        if (invalidateResult.IsFailure)
+        {
+            Log.Warning("Failed to invalidate existing verification codes for user {UserId}", user.Id);
+        }
+
+        var plaintextCode = _tokenService.GenerateVerificationCode();
+        var codeHash = _tokenService.Hash(plaintextCode);
+
+        var verificationCode = new EmailVerificationCode
+        {
+            Id = Guid.NewGuid().ToString(),
+            Created = now,
+            Updated = now,
+            UserId = user.Id,
+            CodeHash = codeHash,
+            Purpose = EmailVerificationCodePurpose.VerifyEmail,
+            ExpiresAt = now.AddMinutes(VerificationCodeTtlMinutes),
+            ConsumedAt = null,
+        };
+
+        var insertResult = await _codesRepository.Insert(verificationCode, ct);
+
+        if (insertResult.IsFailure)
+        {
+            return insertResult;
+        }
+
+        var body =
+            $"Hi {user.Username},\n\n" +
+            $"Your verification code is: {plaintextCode}\n" +
+            $"This code expires in {VerificationCodeTtlMinutes} minutes.\n\n" +
+            "If you did not request this, you can ignore this email.";
+
+        var sendResult = await _emailSender.SendAsync(command.Email, "Verify your email", body, ct);
+
+        if (sendResult.IsFailure)
+        {
+            Log.Warning("Failed to send verification email for user {UserId}: {Error}", user.Id, sendResult.Error);
+        }
+
+        return Result.Success();
+    }
+}

--- a/SplitServer/Commands/SignUpWithPasswordCommand.cs
+++ b/SplitServer/Commands/SignUpWithPasswordCommand.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using MediatR;
 using SplitServer.Responses;
 
@@ -8,4 +8,5 @@ public class SignUpWithPasswordCommand : IRequest<Result<AuthenticationResponse>
 {
     public required string Password { get; init; }
     public required string Username { get; init; }
+    public required string Email { get; init; }
 }

--- a/SplitServer/Commands/SignUpWithPasswordCommandHandler.cs
+++ b/SplitServer/Commands/SignUpWithPasswordCommandHandler.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using SplitServer.Models;
@@ -52,6 +52,18 @@ public class SignUpWithPasswordCommandHandler : IRequestHandler<SignUpWithPasswo
             return Result.Failure<AuthenticationResponse>(usernameValidationResult.Error);
         }
 
+        var emailValidationResult = _validationService.ValidateEmail(command.Email);
+
+        if (emailValidationResult.IsFailure)
+        {
+            return Result.Failure<AuthenticationResponse>(emailValidationResult.Error);
+        }
+
+        if (await _usersRepository.AnyWithEmail(command.Email, ct))
+        {
+            return Result.Failure<AuthenticationResponse>("An account with this email already exists");
+        }
+
         var userId = Guid.NewGuid().ToString();
 
         var hasher = new PasswordHasher<string>();
@@ -65,7 +77,8 @@ public class SignUpWithPasswordCommandHandler : IRequestHandler<SignUpWithPasswo
             Id = userId,
             Created = now,
             Updated = now,
-            Email = null,
+            Email = command.Email,
+            EmailVerified = false,
             HashedPassword = hashedPassword,
             Username = command.Username,
             GoogleId = null,

--- a/SplitServer/Commands/VerifyAccountEmailCommand.cs
+++ b/SplitServer/Commands/VerifyAccountEmailCommand.cs
@@ -1,0 +1,10 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace SplitServer.Commands;
+
+public class VerifyAccountEmailCommand : IRequest<Result>
+{
+    public required string UserId { get; init; }
+    public required string Code { get; init; }
+}

--- a/SplitServer/Commands/VerifyAccountEmailCommandHandler.cs
+++ b/SplitServer/Commands/VerifyAccountEmailCommandHandler.cs
@@ -1,0 +1,97 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+using SplitServer.Models;
+using SplitServer.Repositories;
+using SplitServer.Services.Email;
+
+namespace SplitServer.Commands;
+
+public class VerifyAccountEmailCommandHandler : IRequestHandler<VerifyAccountEmailCommand, Result>
+{
+    private const string InvalidOrExpiredError = "Invalid or expired code";
+
+    private readonly IUsersRepository _usersRepository;
+    private readonly IEmailVerificationCodesRepository _codesRepository;
+    private readonly EmailTokenService _tokenService;
+
+    public VerifyAccountEmailCommandHandler(
+        IUsersRepository usersRepository,
+        IEmailVerificationCodesRepository codesRepository,
+        EmailTokenService tokenService)
+    {
+        _usersRepository = usersRepository;
+        _codesRepository = codesRepository;
+        _tokenService = tokenService;
+    }
+
+    public async Task<Result> Handle(VerifyAccountEmailCommand command, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(command.Code))
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var codeHash = _tokenService.Hash(command.Code);
+
+        var codeMaybe = await _codesRepository.GetActiveByCodeHash(
+            codeHash,
+            EmailVerificationCodePurpose.VerifyEmail,
+            ct);
+
+        if (codeMaybe.HasNoValue)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var code = codeMaybe.Value;
+
+        if (code.UserId != command.UserId)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var now = DateTime.UtcNow;
+
+        if (code.ExpiresAt <= now || code.ConsumedAt is not null)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var userMaybe = await _usersRepository.GetById(code.UserId, ct);
+
+        if (userMaybe.HasNoValue)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var user = userMaybe.Value;
+
+        var updateUserResult = await _usersRepository.Update(
+            user with
+            {
+                EmailVerified = true,
+                Updated = now,
+            },
+            ct);
+
+        if (updateUserResult.IsFailure)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        var consumeResult = await _codesRepository.Update(
+            code with
+            {
+                ConsumedAt = now,
+                Updated = now,
+            },
+            ct);
+
+        if (consumeResult.IsFailure)
+        {
+            return Result.Failure(InvalidOrExpiredError);
+        }
+
+        return Result.Success();
+    }
+}

--- a/SplitServer/Configuration/EmailSettings.cs
+++ b/SplitServer/Configuration/EmailSettings.cs
@@ -1,0 +1,14 @@
+namespace SplitServer.Configuration;
+
+public class EmailSettings : ISettings
+{
+    public required string SectionName { get; init; } = "Email";
+    public required bool Enabled { get; init; }
+    public required string SmtpHost { get; init; }
+    public required int SmtpPort { get; init; }
+    public required bool UseStartTls { get; init; }
+    public required string Username { get; init; }
+    public required string Password { get; init; }
+    public required string FromAddress { get; init; }
+    public required string FromName { get; init; }
+}

--- a/SplitServer/Endpoints/AuthEndpoints.cs
+++ b/SplitServer/Endpoints/AuthEndpoints.cs
@@ -1,8 +1,10 @@
-﻿using MediatR;
+using MediatR;
 using SplitServer.Commands;
+using SplitServer.Extensions;
 using SplitServer.Requests;
 using SplitServer.Responses;
 using SplitServer.Services.Auth;
+using SplitServer.Services.Email;
 
 namespace SplitServer.Endpoints;
 
@@ -12,6 +14,11 @@ public static class AuthEndpoints
     {
         app.MapPost("/password/sign-up", PasswordSignUpHandler);
         app.MapPost("/password/sign-in", PasswordSignInHandler);
+        app.MapPost("/password/forgot", ForgotPasswordHandler);
+        app.MapPost("/password/reset", ResetPasswordHandler);
+        app.MapPost("/username/forgot", ForgotUsernameHandler);
+        app.MapPost("/account/email", SetAccountEmailHandler).RequireAuthorization();
+        app.MapPost("/account/email/verify", VerifyAccountEmailHandler).RequireAuthorization();
         app.MapPost("/external/google/token", GoogleTokenHandler);
         app.MapPost("/refresh", RefreshHandler);
         app.MapPost("/log-out", LogOutHandler);
@@ -56,7 +63,8 @@ public static class AuthEndpoints
         var command = new SignUpWithPasswordCommand
         {
             Password = request.Password,
-            Username = request.Username
+            Username = request.Username,
+            Email = request.Email
         };
 
         var result = await mediator.Send(command, ct);
@@ -105,6 +113,112 @@ public static class AuthEndpoints
         };
 
         return Results.Ok(response);
+    }
+
+    private static async Task<IResult> ForgotPasswordHandler(
+        ForgotPasswordRequest request,
+        IMediator mediator,
+        HttpContext httpContext,
+        EmailThrottleService throttleService,
+        CancellationToken ct)
+    {
+        var ip = GetClientIp(httpContext);
+
+        if (!throttleService.TryConsume("password-forgot", ip, request.Email ?? ""))
+        {
+            return Results.Ok();
+        }
+
+        await mediator.Send(new RequestPasswordResetCommand { Email = request.Email ?? "" }, ct);
+
+        return Results.Ok();
+    }
+
+    private static async Task<IResult> ResetPasswordHandler(
+        ResetPasswordRequest request,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var command = new ResetPasswordCommand
+        {
+            Token = request.Token,
+            NewPassword = request.NewPassword,
+        };
+
+        var result = await mediator.Send(command, ct);
+
+        return result.IsFailure ? Results.BadRequest(result.Error) : Results.Ok();
+    }
+
+    private static async Task<IResult> ForgotUsernameHandler(
+        ForgotUsernameRequest request,
+        IMediator mediator,
+        HttpContext httpContext,
+        EmailThrottleService throttleService,
+        CancellationToken ct)
+    {
+        var ip = GetClientIp(httpContext);
+
+        if (!throttleService.TryConsume("username-forgot", ip, request.Email ?? ""))
+        {
+            return Results.Ok();
+        }
+
+        await mediator.Send(new RequestUsernameRecoveryCommand { Email = request.Email ?? "" }, ct);
+
+        return Results.Ok();
+    }
+
+    private static async Task<IResult> SetAccountEmailHandler(
+        SetAccountEmailRequest request,
+        IMediator mediator,
+        HttpContext httpContext,
+        EmailThrottleService throttleService,
+        CancellationToken ct)
+    {
+        var ip = GetClientIp(httpContext);
+        var userId = httpContext.GetUserId();
+
+        if (!throttleService.TryConsume("set-email", ip, userId))
+        {
+            return Results.BadRequest("Too many requests. Please try again later.");
+        }
+
+        var command = new SetAccountEmailCommand
+        {
+            UserId = userId,
+            Email = request.Email,
+        };
+
+        var result = await mediator.Send(command, ct);
+
+        return result.IsFailure ? Results.BadRequest(result.Error) : Results.Ok();
+    }
+
+    private static async Task<IResult> VerifyAccountEmailHandler(
+        VerifyAccountEmailRequest request,
+        IMediator mediator,
+        HttpContext httpContext,
+        EmailThrottleService throttleService,
+        CancellationToken ct)
+    {
+        var ip = GetClientIp(httpContext);
+        var userId = httpContext.GetUserId();
+
+        if (!throttleService.TryConsume("verify-email", ip, userId))
+        {
+            return Results.BadRequest("Too many requests. Please try again later.");
+        }
+
+        var command = new VerifyAccountEmailCommand
+        {
+            UserId = userId,
+            Code = request.Code,
+        };
+
+        var result = await mediator.Send(command, ct);
+
+        return result.IsFailure ? Results.BadRequest(result.Error) : Results.Ok();
     }
 
     private static async Task<IResult> RefreshHandler(
@@ -173,5 +287,10 @@ public static class AuthEndpoints
         authService.DeleteRefreshTokenCookie(httpContext);
 
         return Results.Ok();
+    }
+
+    private static string GetClientIp(HttpContext httpContext)
+    {
+        return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
     }
 }

--- a/SplitServer/Models/EmailVerificationCode.cs
+++ b/SplitServer/Models/EmailVerificationCode.cs
@@ -1,0 +1,10 @@
+namespace SplitServer.Models;
+
+public record EmailVerificationCode : EntityBase
+{
+    public required string UserId { get; init; }
+    public required string CodeHash { get; init; }
+    public required EmailVerificationCodePurpose Purpose { get; init; }
+    public required DateTime ExpiresAt { get; init; }
+    public required DateTime? ConsumedAt { get; init; }
+}

--- a/SplitServer/Models/EmailVerificationCodePurpose.cs
+++ b/SplitServer/Models/EmailVerificationCodePurpose.cs
@@ -1,0 +1,7 @@
+namespace SplitServer.Models;
+
+public enum EmailVerificationCodePurpose
+{
+    VerifyEmail = 0,
+    PasswordReset = 1
+}

--- a/SplitServer/Models/User.cs
+++ b/SplitServer/Models/User.cs
@@ -1,8 +1,9 @@
-﻿namespace SplitServer.Models;
+namespace SplitServer.Models;
 
 public record User : EntityBase
 {
     public required string? Email { get; init; }
+    public required bool EmailVerified { get; init; }
     public required string? HashedPassword { get; init; }
     public required string Username { get; init; }
     public required string? GoogleId { get; init; }

--- a/SplitServer/Program.cs
+++ b/SplitServer/Program.cs
@@ -11,6 +11,7 @@ using SplitServer.Repositories.Implementations;
 using SplitServer.Services;
 using SplitServer.Services.Auth;
 using SplitServer.Services.CurrencyExchangeRate;
+using SplitServer.Services.Email;
 using SplitServer.Services.OpenExchangeRates;
 using SplitServer.Services.TimeZone;
 
@@ -53,6 +54,11 @@ builder.Services.AddSingleton<IUserActivityRepository, UserActivityMongoDbReposi
 builder.Services.AddSingleton<IUserPreferencesRepository, UserPreferencesMongoDbRepository>();
 builder.Services.AddSingleton<IUserLabelsRepository, UserLabelsMongoDbRepository>();
 builder.Services.AddSingleton<IBudgetsRepository, BudgetsMongoDbRepository>();
+builder.Services.AddSingleton<IEmailVerificationCodesRepository, EmailVerificationCodesMongoDbRepository>();
+
+builder.Services.AddMemoryCache();
+builder.Services.AddSingleton<EmailTokenService>();
+builder.Services.AddSingleton<EmailThrottleService>();
 
 builder.Configure<MongoDbSettings>();
 builder.Configure<JoinSettings>();
@@ -60,6 +66,17 @@ builder.Configure<OpenExchangeRatesSettings>();
 builder.Configure<ErrorHandlingSettings>();
 var openTelemetrySettings = builder.Configure<OpenTelemetrySettings>();
 var authSettings = builder.Configure<AuthSettings>();
+var emailSettings = builder.Configure<EmailSettings>();
+
+if (emailSettings.Enabled)
+{
+    builder.Services.AddSingleton<IEmailSender, SmtpEmailSender>();
+}
+else
+{
+    builder.Services.AddSingleton<IEmailSender, NullEmailSender>();
+}
+
 builder.Services.AddAuthentication(authSettings);
 builder.Services.AddAuthorization();
 builder.Services.AddEndpointsApiExplorer();

--- a/SplitServer/Repositories/IEmailVerificationCodesRepository.cs
+++ b/SplitServer/Repositories/IEmailVerificationCodesRepository.cs
@@ -1,0 +1,17 @@
+using CSharpFunctionalExtensions;
+using SplitServer.Models;
+
+namespace SplitServer.Repositories;
+
+public interface IEmailVerificationCodesRepository : IRepositoryBase<EmailVerificationCode>
+{
+    Task<Maybe<EmailVerificationCode>> GetActiveByCodeHash(
+        string codeHash,
+        EmailVerificationCodePurpose purpose,
+        CancellationToken ct);
+
+    Task<Result> InvalidateActiveCodes(
+        string userId,
+        EmailVerificationCodePurpose purpose,
+        CancellationToken ct);
+}

--- a/SplitServer/Repositories/ISessionsRepository.cs
+++ b/SplitServer/Repositories/ISessionsRepository.cs
@@ -8,4 +8,6 @@ public interface ISessionsRepository : IRepositoryBase<Session>
     Task<Maybe<Session>> GetByRefreshToken(string refreshToken, CancellationToken ct);
 
     Task<Result> DeleteByRefreshToken(string refreshToken, CancellationToken ct);
+
+    Task<Result> DeleteByUserId(string userId, CancellationToken ct);
 }

--- a/SplitServer/Repositories/IUsersRepository.cs
+++ b/SplitServer/Repositories/IUsersRepository.cs
@@ -16,4 +16,6 @@ public interface IUsersRepository : IRepositoryBase<User>
     Task<List<User>> GetLatestUsers(int skip, int pageSize, CancellationToken ct);
 
     Task<bool> AnyWithUsername(string username, CancellationToken ct);
+
+    Task<bool> AnyWithEmail(string email, CancellationToken ct);
 }

--- a/SplitServer/Repositories/Implementations/EmailVerificationCodesMongoDbRepository.cs
+++ b/SplitServer/Repositories/Implementations/EmailVerificationCodesMongoDbRepository.cs
@@ -1,0 +1,52 @@
+using CSharpFunctionalExtensions;
+using MongoDB.Driver;
+using SplitServer.Models;
+using SplitServer.Repositories.Mappers;
+
+namespace SplitServer.Repositories.Implementations;
+
+public class EmailVerificationCodesMongoDbRepository
+    : MongoDbRepositoryBase<EmailVerificationCode, EmailVerificationCode>, IEmailVerificationCodesRepository
+{
+    public EmailVerificationCodesMongoDbRepository(IMongoConnection mongoConnection) :
+        base(
+            mongoConnection,
+            "EmailVerificationCodes",
+            new PassThroughMapper<EmailVerificationCode>())
+    {
+    }
+
+    public async Task<Maybe<EmailVerificationCode>> GetActiveByCodeHash(
+        string codeHash,
+        EmailVerificationCodePurpose purpose,
+        CancellationToken ct)
+    {
+        var filter = FilterBuilder.And(
+            FilterBuilder.Eq(x => x.CodeHash, codeHash),
+            FilterBuilder.Eq(x => x.Purpose, purpose),
+            FilterBuilder.Eq(x => x.ConsumedAt, null));
+
+        return await Collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<Result> InvalidateActiveCodes(
+        string userId,
+        EmailVerificationCodePurpose purpose,
+        CancellationToken ct)
+    {
+        var filter = FilterBuilder.And(
+            FilterBuilder.Eq(x => x.UserId, userId),
+            FilterBuilder.Eq(x => x.Purpose, purpose),
+            FilterBuilder.Eq(x => x.ConsumedAt, null));
+
+        var update = UpdateBuilder
+            .Set(x => x.ConsumedAt, DateTime.UtcNow)
+            .Set(x => x.Updated, DateTime.UtcNow);
+
+        var result = await Collection.UpdateManyAsync(filter, update, cancellationToken: ct);
+
+        return result.IsAcknowledged
+            ? Result.Success()
+            : Result.Failure("Failed to invalidate active codes");
+    }
+}

--- a/SplitServer/Repositories/Implementations/SessionsMongoDbRepository.cs
+++ b/SplitServer/Repositories/Implementations/SessionsMongoDbRepository.cs
@@ -35,4 +35,18 @@ public class SessionsMongoDbRepository : MongoDbRepositoryBase<Session, Session>
 
         return Result.Success();
     }
+
+    public async Task<Result> DeleteByUserId(string userId, CancellationToken ct)
+    {
+        var filter = Builders<Session>.Filter.Eq(x => x.UserId, userId);
+
+        var deleteResult = await Collection.DeleteManyAsync(filter, ct);
+
+        if (!deleteResult.IsAcknowledged)
+        {
+            return Result.Failure<Result>("Failed to delete sessions");
+        }
+
+        return Result.Success();
+    }
 }

--- a/SplitServer/Repositories/Implementations/UsersMongoDbRepository.cs
+++ b/SplitServer/Repositories/Implementations/UsersMongoDbRepository.cs
@@ -20,9 +20,7 @@ public class UsersMongoDbRepository : MongoDbRepositoryBase<User, User>, IUsersR
 
     public async Task<Maybe<User>> GetByEmail(string email, CancellationToken ct)
     {
-        var filter = FilterBuilder.Eq(x => x.Email, email);
-
-        return await Collection.Find(filter).SingleOrDefaultAsync(ct);
+        return await Collection.Find(EmailFilter(email)).SingleOrDefaultAsync(ct);
     }
 
     public async Task<Maybe<User>> GetByUsername(string username, CancellationToken ct)
@@ -71,8 +69,20 @@ public class UsersMongoDbRepository : MongoDbRepositoryBase<User, User>, IUsersR
             .AnyAsync(ct);
     }
 
+    public async Task<bool> AnyWithEmail(string email, CancellationToken ct)
+    {
+        return await Collection
+            .Find(EmailFilter(email))
+            .AnyAsync(ct);
+    }
+
     private static FilterDefinition<User> UsernameFilter(string username)
     {
         return FilterBuilder.Regex(x => x.Username, new BsonRegularExpression($"^{Regex.Escape(username)}$", "i"));
+    }
+
+    private static FilterDefinition<User> EmailFilter(string email)
+    {
+        return FilterBuilder.Regex(x => x.Email, new BsonRegularExpression($"^{Regex.Escape(email)}$", "i"));
     }
 }

--- a/SplitServer/Requests/ForgotPasswordRequest.cs
+++ b/SplitServer/Requests/ForgotPasswordRequest.cs
@@ -1,0 +1,6 @@
+namespace SplitServer.Requests;
+
+public class ForgotPasswordRequest
+{
+    public required string Email { get; init; }
+}

--- a/SplitServer/Requests/ForgotUsernameRequest.cs
+++ b/SplitServer/Requests/ForgotUsernameRequest.cs
@@ -1,0 +1,6 @@
+namespace SplitServer.Requests;
+
+public class ForgotUsernameRequest
+{
+    public required string Email { get; init; }
+}

--- a/SplitServer/Requests/PasswordSignUpRequest.cs
+++ b/SplitServer/Requests/PasswordSignUpRequest.cs
@@ -1,7 +1,8 @@
-﻿namespace SplitServer.Requests;
+namespace SplitServer.Requests;
 
 public class PasswordSignUpRequest
 {
     public required string Password { get; init; }
     public required string Username { get; init; }
+    public required string Email { get; init; }
 }

--- a/SplitServer/Requests/ResetPasswordRequest.cs
+++ b/SplitServer/Requests/ResetPasswordRequest.cs
@@ -1,0 +1,7 @@
+namespace SplitServer.Requests;
+
+public class ResetPasswordRequest
+{
+    public required string Token { get; init; }
+    public required string NewPassword { get; init; }
+}

--- a/SplitServer/Requests/SetAccountEmailRequest.cs
+++ b/SplitServer/Requests/SetAccountEmailRequest.cs
@@ -1,0 +1,6 @@
+namespace SplitServer.Requests;
+
+public class SetAccountEmailRequest
+{
+    public required string Email { get; init; }
+}

--- a/SplitServer/Requests/VerifyAccountEmailRequest.cs
+++ b/SplitServer/Requests/VerifyAccountEmailRequest.cs
@@ -1,0 +1,6 @@
+namespace SplitServer.Requests;
+
+public class VerifyAccountEmailRequest
+{
+    public required string Code { get; init; }
+}

--- a/SplitServer/Services/Email/EmailThrottleService.cs
+++ b/SplitServer/Services/Email/EmailThrottleService.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace SplitServer.Services.Email;
+
+public class EmailThrottleService
+{
+    private const int DefaultBucketCapacity = 5;
+    private static readonly TimeSpan DefaultWindow = TimeSpan.FromMinutes(15);
+
+    private readonly IMemoryCache _cache;
+
+    public EmailThrottleService(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
+
+    public bool TryConsume(string operation, string ip, string emailOrUserId)
+    {
+        var key = $"email-throttle:{operation}:{ip}:{emailOrUserId.ToLowerInvariant()}";
+
+        var bucket = _cache.GetOrCreate(key, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = DefaultWindow;
+            return new TokenBucket(DefaultBucketCapacity, DefaultWindow);
+        })!;
+
+        return bucket.TryConsume();
+    }
+
+    private class TokenBucket
+    {
+        private readonly object _lock = new();
+        private readonly int _capacity;
+        private readonly TimeSpan _refillInterval;
+        private double _tokens;
+        private DateTime _lastRefill;
+
+        public TokenBucket(int capacity, TimeSpan refillInterval)
+        {
+            _capacity = capacity;
+            _refillInterval = refillInterval;
+            _tokens = capacity;
+            _lastRefill = DateTime.UtcNow;
+        }
+
+        public bool TryConsume()
+        {
+            lock (_lock)
+            {
+                Refill();
+
+                if (_tokens < 1)
+                {
+                    return false;
+                }
+
+                _tokens -= 1;
+                return true;
+            }
+        }
+
+        private void Refill()
+        {
+            var now = DateTime.UtcNow;
+            var elapsed = now - _lastRefill;
+
+            if (elapsed <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            var refillRatePerSecond = _capacity / _refillInterval.TotalSeconds;
+            _tokens = Math.Min(_capacity, _tokens + elapsed.TotalSeconds * refillRatePerSecond);
+            _lastRefill = now;
+        }
+    }
+}

--- a/SplitServer/Services/Email/EmailTokenService.cs
+++ b/SplitServer/Services/Email/EmailTokenService.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SplitServer.Services.Email;
+
+public class EmailTokenService
+{
+    private const int PasswordResetTokenByteLength = 32;
+    private const int VerificationCodeDigits = 6;
+
+    public string GeneratePasswordResetToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(PasswordResetTokenByteLength);
+        return Base64UrlEncode(bytes);
+    }
+
+    public string GenerateVerificationCode()
+    {
+        var builder = new StringBuilder(VerificationCodeDigits);
+
+        for (var i = 0; i < VerificationCodeDigits; i++)
+        {
+            builder.Append(RandomNumberGenerator.GetInt32(0, 10));
+        }
+
+        return builder.ToString();
+    }
+
+    public string Hash(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes)
+    {
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/SplitServer/Services/Email/IEmailSender.cs
+++ b/SplitServer/Services/Email/IEmailSender.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace SplitServer.Services.Email;
+
+public interface IEmailSender
+{
+    Task<Result> SendAsync(string toAddress, string subject, string body, CancellationToken ct);
+}

--- a/SplitServer/Services/Email/NullEmailSender.cs
+++ b/SplitServer/Services/Email/NullEmailSender.cs
@@ -1,0 +1,14 @@
+using CSharpFunctionalExtensions;
+using Serilog;
+
+namespace SplitServer.Services.Email;
+
+public class NullEmailSender : IEmailSender
+{
+    public Task<Result> SendAsync(string toAddress, string subject, string body, CancellationToken ct)
+    {
+        Log.Information("[NullEmailSender] To: {To} | Subject: {Subject}\n{Body}", toAddress, subject, body);
+
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/SplitServer/Services/Email/SmtpEmailSender.cs
+++ b/SplitServer/Services/Email/SmtpEmailSender.cs
@@ -1,0 +1,54 @@
+using CSharpFunctionalExtensions;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using Serilog;
+using SplitServer.Configuration;
+
+namespace SplitServer.Services.Email;
+
+public class SmtpEmailSender : IEmailSender
+{
+    private readonly EmailSettings _emailSettings;
+
+    public SmtpEmailSender(IOptions<EmailSettings> emailSettings)
+    {
+        _emailSettings = emailSettings.Value;
+    }
+
+    public async Task<Result> SendAsync(string toAddress, string subject, string body, CancellationToken ct)
+    {
+        try
+        {
+            var message = new MimeMessage();
+            message.From.Add(new MailboxAddress(_emailSettings.FromName, _emailSettings.FromAddress));
+            message.To.Add(MailboxAddress.Parse(toAddress));
+            message.Subject = subject;
+            message.Body = new TextPart("plain") { Text = body };
+
+            using var client = new SmtpClient();
+
+            var socketOptions = _emailSettings.UseStartTls
+                ? SecureSocketOptions.StartTls
+                : SecureSocketOptions.Auto;
+
+            await client.ConnectAsync(_emailSettings.SmtpHost, _emailSettings.SmtpPort, socketOptions, ct);
+
+            if (!string.IsNullOrEmpty(_emailSettings.Username))
+            {
+                await client.AuthenticateAsync(_emailSettings.Username, _emailSettings.Password, ct);
+            }
+
+            await client.SendAsync(message, ct);
+            await client.DisconnectAsync(true, ct);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to send email to {ToAddress}", toAddress);
+            return Result.Failure($"Failed to send email: {ex.Message}");
+        }
+    }
+}

--- a/SplitServer/Services/ValidationService.cs
+++ b/SplitServer/Services/ValidationService.cs
@@ -1,6 +1,8 @@
-﻿using CSharpFunctionalExtensions;
+﻿using System.Text.RegularExpressions;
+using CSharpFunctionalExtensions;
 using NMoneys;
 using SplitServer.Models;
+using Group = SplitServer.Models.Group;
 
 // ReSharper disable ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
 
@@ -10,6 +12,11 @@ public class ValidationService
 {
     public const int UsernameMinLength = 4;
     public const int UsernameMaxLength = 16;
+    public const int EmailMaxLength = 254;
+
+    private static readonly Regex EmailRegex = new(
+        @"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public HashSet<char> UsernameAllowedChars { get; } = new("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.");
 
@@ -42,6 +49,26 @@ public class ValidationService
         if (_usernameForbiddenSequences.Any(username.Contains))
         {
             return Result.Failure("Username cannot contain consecutive special characters");
+        }
+
+        return Result.Success();
+    }
+
+    public Result ValidateEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return Result.Failure("Email is required");
+        }
+
+        if (email.Length > EmailMaxLength)
+        {
+            return Result.Failure($"Email length must be at most {EmailMaxLength}");
+        }
+
+        if (!EmailRegex.IsMatch(email))
+        {
+            return Result.Failure("Email is not a valid email address");
         }
 
         return Result.Success();

--- a/SplitServer/SplitServer.csproj
+++ b/SplitServer/SplitServer.csproj
@@ -4,10 +4,11 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2605.3</Version>
+    <Version>2605.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="3.2.0"/>
+    <PackageReference Include="MailKit" Version="4.7.1.1"/>
     <PackageReference Include="MediatR" Version="12.5.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14"/>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3"/>

--- a/SplitServer/appsettings.json
+++ b/SplitServer/appsettings.json
@@ -5,5 +5,15 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Email": {
+    "Enabled": false,
+    "SmtpHost": "",
+    "SmtpPort": 587,
+    "UseStartTls": true,
+    "Username": "",
+    "Password": "",
+    "FromAddress": "oxd6o63lhr@bwmyga.com",
+    "FromName": "SplitServer"
+  }
 }


### PR DESCRIPTION
Implements #110.

## Summary
- Password sign-up now requires a validated email (stored unverified); duplicates rejected
- New endpoints: `/password/forgot`, `/password/reset`, `/username/forgot`, `/account/email`, `/account/email/verify`
- New `EmailVerificationCode` aggregate + Mongo repo, SHA-256 hashed, with `Purpose` enum (`VerifyEmail` / `PasswordReset`)
- `IEmailSender` abstraction with MailKit SMTP and Null implementations, selected by new `EmailSettings.Enabled`
- Per-(IP, email|userId) token-bucket throttling on abuse-sensitive endpoints via `IMemoryCache`
- Reset invalidates all active sessions (`ISessionsRepository.DeleteByUserId`)
- Google sign-ups now set `EmailVerified = true`
- `ValidationService.ValidateEmail` + unit tests

## Test plan
- [ ] `dotnet build` and `dotnet test` pass
- [ ] Sign-up with valid email works; duplicate email rejected
- [ ] Google sign-in still works and user has `EmailVerified = true`
- [ ] Forgot-password flow against Mailtrap: link delivered, reset works, all sessions killed
- [ ] Forgot-username flow: username delivered for verified email, 200 with no mail for unverified/unknown
- [ ] Add/verify email for a user with `Email == null`

Generated with [Claude Code](https://claude.ai/code)